### PR TITLE
Support estatico newtypes

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.12, 2.13.4]
+        scala: [2.12.13, 2.13.4]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 .bloop
 .vscode
 metals.sbt
+.bsp
+.metals

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 name := "derevo"
 import com.typesafe.sbt.SbtGit.git
 
-val publishVersion = "0.11.6"
+val publishVersion = "0.12.0"
 
 val common = List(
   scalaVersion := "2.13.4",
-  crossScalaVersions := List("2.12.12", "2.13.4"),
+  crossScalaVersions := List("2.12.13", "2.13.4"),
   libraryDependencies += scalaOrganization.value % "scala-reflect" % scalaVersion.value % Provided,
   libraryDependencies ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
@@ -21,9 +21,14 @@ val common = List(
     "-language:higherKinds",
     "-Xfatal-warnings",
   ),
+  Test / scalacOptions ++= Vector(
+    "-language:implicitConversions",
+  ),
+  libraryDependencies += "io.estatico"          %% "newtype"       % "0.4.4"            % Test,
+  libraryDependencies += "org.scalameta"        %% "munit"         % Version.munit      % "test",
+  libraryDependencies += "org.scalatest"        %% "scalatest"     % Version.scalaTest  % "test",
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, y)) if y == 11 => Seq("-Xexperimental")
       case Some((2, y)) if y == 13 => Seq("-Ymacro-annotations")
       case _                       => Seq.empty[String]
     }
@@ -76,7 +81,7 @@ lazy val core = project settings common settings (
       s"""{"artifact": "$integrationOrg % ${integrationName}_2.13 % $integrationVersion"}""".stripMargin
     )
     Seq(intellijCompatFile)
-  }
+  },
 )
 
 lazy val cats           = project dependsOn core settings common

--- a/cats/src/main/scala/derevo/cats/eq.scala
+++ b/cats/src/main/scala/derevo/cats/eq.scala
@@ -3,8 +3,9 @@ package derevo.cats
 import cats.Eq
 import magnolia.{CaseClass, Magnolia, SealedTrait}
 import derevo.Derivation
+import derevo.NewTypeDerivation
 
-object eq extends Derivation[Eq] {
+object eq extends Derivation[Eq] with NewTypeDerivation[Eq] {
   type Typeclass[T] = Eq[T]
 
   def combine[T](ctx: CaseClass[Eq, T]): Eq[T] = new Eq[T] {

--- a/cats/src/main/scala/derevo/cats/monoid.scala
+++ b/cats/src/main/scala/derevo/cats/monoid.scala
@@ -3,8 +3,10 @@ package derevo.cats
 import cats.Monoid
 import magnolia.{CaseClass, Magnolia, SealedTrait}
 import derevo.Derivation
+import scala.annotation.implicitNotFound
+import derevo.NewTypeDerivation
 
-object monoid extends Derivation[Monoid] {
+object monoid extends Derivation[Monoid] with NewTypeDerivation[Monoid] {
   type Typeclass[T] = Monoid[T]
 
   def combine[T](ctx: CaseClass[Monoid, T]): Monoid[T] = new Monoid[T] {
@@ -13,7 +15,12 @@ object monoid extends Derivation[Monoid] {
     override def empty: T               = ctx.construct(_.typeclass.empty)
   }
 
-  def dispatch[T](ctx: SealedTrait[Monoid, T]): Monoid[T] = ???
+  def dispatch[T](ctx: SealedTrait[Monoid, T])(implicit absurd: MonoidSumAbsurd): Monoid[T] = absurd.mon
 
   implicit def instance[T]: Monoid[T] = macro Magnolia.gen[T]
+}
+
+@implicitNotFound("Can not derive Monoids for sealed families")
+abstract class MonoidSumAbsurd {
+  def mon[A]: Monoid[A]
 }

--- a/cats/src/main/scala/derevo/cats/ord.scala
+++ b/cats/src/main/scala/derevo/cats/ord.scala
@@ -3,8 +3,9 @@ package derevo.cats
 import cats.Order
 import magnolia.{CaseClass, Magnolia, SealedTrait}
 import derevo.Derivation
+import derevo.NewTypeDerivation
 
-object order extends Derivation[Order] {
+object order extends Derivation[Order] with NewTypeDerivation[Order] {
   type Typeclass[T] = Order[T]
 
   def combine[T](ctx: CaseClass[Order, T]): Order[T] = new Order[T] {

--- a/cats/src/main/scala/derevo/cats/semigroup.scala
+++ b/cats/src/main/scala/derevo/cats/semigroup.scala
@@ -3,8 +3,10 @@ package derevo.cats
 import cats.Semigroup
 import magnolia.{CaseClass, Magnolia, SealedTrait}
 import derevo.Derivation
+import scala.annotation.implicitNotFound
+import derevo.NewTypeDerivation
 
-object semigroup extends Derivation[Semigroup] {
+object semigroup extends Derivation[Semigroup] with NewTypeDerivation[Semigroup] {
   type Typeclass[T] = Semigroup[T]
 
   def combine[T](ctx: CaseClass[Semigroup, T]): Semigroup[T] = new Semigroup[T] {
@@ -12,6 +14,11 @@ object semigroup extends Derivation[Semigroup] {
       ctx.construct(param => param.typeclass.combine(param.dereference(x), param.dereference(y)))
   }
 
-  def dispatch[T](ctx: SealedTrait[Semigroup, T]): Semigroup[T] = ???
+  def dispatch[T](ctx: SealedTrait[Semigroup, T])(implicit absurd: SemigroupSumAbsurd): Semigroup[T] = absurd.sg
   implicit def instance[T]: Semigroup[T] = macro Magnolia.gen[T]
+}
+
+@implicitNotFound("Can not derive Semigroups for sealed families")
+abstract class SemigroupSumAbsurd {
+  def sg[A]: Semigroup[A]
 }

--- a/cats/src/main/scala/derevo/cats/show.scala
+++ b/cats/src/main/scala/derevo/cats/show.scala
@@ -4,7 +4,7 @@ package cats
 import _root_.cats.Show
 import magnolia.{CaseClass, Magnolia, SealedTrait}
 
-object show extends Derivation[Show] {
+object show extends Derivation[Show] with NewTypeDerivation[Show] {
   type Typeclass[T] = Show[T]
 
   def combine[T](ctx: CaseClass[Show, T]): Show[T] = new Show[T] {

--- a/cats/src/test/scala/derevo/cats/EqSpec.scala
+++ b/cats/src/test/scala/derevo/cats/EqSpec.scala
@@ -4,6 +4,7 @@ import cats.Eq
 import derevo.cats.{eq => eqv}
 import derevo.derive
 import org.scalatest.freespec.AnyFreeSpec
+import io.estatico.newtype.macros.newtype
 
 class EqSpec extends AnyFreeSpec {
 
@@ -19,6 +20,13 @@ class EqSpec extends AnyFreeSpec {
         assert(Eq[Qux].neqv(Qux(1), Qux(-1)))
       }
 
+      "through newtype casting" - {
+        import derevo.cats.EqSpec.Jankurpo
+
+        assert(Eq[Jankurpo].eqv(Jankurpo("a"), Jankurpo("a")))
+        assert(Eq[Jankurpo].neqv(Jankurpo("a"), Jankurpo("b")))
+      }
+
       "through Eq.fromUniversalEquals" in {
         @derive(eqv.universal)
         case class Qux(a: Int)
@@ -28,4 +36,10 @@ class EqSpec extends AnyFreeSpec {
       }
     }
   }
+}
+
+object EqSpec {
+  @derive(eqv)
+  @newtype
+  case class Jankurpo(a: String)
 }

--- a/circe/build.sbt
+++ b/circe/build.sbt
@@ -1,6 +1,5 @@
 moduleName := "derevo-circe"
 
-libraryDependencies += "io.circe"      %% "circe-core"       % Version.circe
-libraryDependencies += "io.circe"      %% "circe-derivation" % Version.circeDerivation
-libraryDependencies += "io.circe"      %% "circe-parser"     % Version.circe     % "test"
-libraryDependencies += "org.scalatest" %% "scalatest"        % Version.scalaTest % "test"
+libraryDependencies += "io.circe" %% "circe-core"       % Version.circe
+libraryDependencies += "io.circe" %% "circe-derivation" % Version.circeDerivation
+libraryDependencies += "io.circe" %% "circe-parser"     % Version.circe % "test"

--- a/circe/src/main/scala/derevo/circe/circe.scala
+++ b/circe/src/main/scala/derevo/circe/circe.scala
@@ -3,9 +3,10 @@ package derevo.circe
 import derevo.{Derevo, Derivation, PolyDerivation, delegating}
 import io.circe.derivation.renaming
 import io.circe.{Codec, Decoder, Encoder}
+import derevo.NewTypeDerivation
 
 @delegating("io.circe.derivation.deriveDecoder")
-object decoder extends Derivation[Decoder] {
+object decoder extends Derivation[Decoder] with NewTypeDerivation[Decoder] {
   def instance[A]: Decoder[A] = macro Derevo.delegate[Decoder, A]
 
   /** @param arg1 naming function. For example io.circe.derivation.renaming.snakeCase
@@ -17,7 +18,7 @@ object decoder extends Derivation[Decoder] {
 }
 
 @delegating("io.circe.derivation.deriveEncoder")
-object encoder extends PolyDerivation[Encoder, Encoder.AsObject] {
+object encoder extends PolyDerivation[Encoder, Encoder.AsObject] with NewTypeDerivation[Encoder] {
   def instance[A]: Encoder.AsObject[A] = macro Derevo.delegate[Encoder.AsObject, A]
 
   /** @param arg1 naming function. For example io.circe.derivation.renaming.snakeCase
@@ -28,7 +29,7 @@ object encoder extends PolyDerivation[Encoder, Encoder.AsObject] {
 }
 
 @delegating("io.circe.derivation.deriveCodec")
-object codec extends PolyDerivation[Codec, Codec.AsObject] {
+object codec extends PolyDerivation[Codec, Codec.AsObject] with NewTypeDerivation[Codec] {
   def instance[A]: Codec.AsObject[A] = macro Derevo.delegate[Codec.AsObject, A]
 
   /** @param arg1 naming function. For example io.circe.derivation.renaming.snakeCase

--- a/circeMagnolia/src/main/scala/derevo/circe/magnolia/circe.scala
+++ b/circeMagnolia/src/main/scala/derevo/circe/magnolia/circe.scala
@@ -3,14 +3,15 @@ package derevo.circe.magnolia
 import derevo.{Derevo, Derivation, PolyDerivation, delegating}
 import io.circe.magnolia.configured.Configuration
 import io.circe.{Decoder, Encoder}
+import derevo.NewTypeDerivation
 
 @delegating("io.circe.magnolia.derivation.decoder.semiauto.deriveMagnoliaDecoder")
-object decoder extends Derivation[Decoder] {
+object decoder extends Derivation[Decoder] with NewTypeDerivation[Decoder] {
   def instance[A]: Decoder[A] = macro Derevo.delegate[Decoder, A]
 }
 
 @delegating("io.circe.magnolia.derivation.encoder.semiauto.deriveMagnoliaEncoder")
-object encoder extends Derivation[Encoder] {
+object encoder extends Derivation[Encoder] with NewTypeDerivation[Encoder] {
   def instance[A]: Encoder[A] = macro Derevo.delegate[Encoder, A]
 }
 

--- a/ciris/src/main/scala/derevo/ciris/ciris.scala
+++ b/ciris/src/main/scala/derevo/ciris/ciris.scala
@@ -9,8 +9,9 @@ import magnolia.{CaseClass, Magnolia, SealedTrait}
 import derevo.Derivation
 
 import scala.language.experimental.macros
+import derevo.NewTypeDerivation
 
-object cirisDecoder extends Derivation[ConfigValueDecoder] {
+object cirisDecoder extends Derivation[ConfigValueDecoder] with NewTypeDerivation[ConfigValueDecoder] {
   type Typeclass[T]  = ConfigValueDecoder[T]
   type ErrorOrParams = Either[ConfigError, List[Any]]
 

--- a/core/src/main/scala/derevo/NewTypeRepr.scala
+++ b/core/src/main/scala/derevo/NewTypeRepr.scala
@@ -1,0 +1,10 @@
+package derevo
+
+/** Utilitary holder for the newtype instance derivation */
+class NewTypeRepr[TC[_], R](private val repr: TC[R]) extends AnyVal {
+  def instance[A]: TC[A] = repr.asInstanceOf[TC[A]]
+}
+
+trait NewTypeDerivation[TC[_]] {
+  final def newtype[R](implicit repr: TC[R]): NewTypeRepr[TC, R] = new NewTypeRepr[TC, R](repr)
+}

--- a/core/src/test/scala/derevo/KyonSuite.scala
+++ b/core/src/test/scala/derevo/KyonSuite.scala
@@ -1,0 +1,31 @@
+package derevo
+
+import io.estatico.newtype.macros.newtype
+import scala.language.implicitConversions
+import scala.reflect.{ClassTag, classTag}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class Kyon[A](val cls: Any)
+
+object Kyon extends Derivation[Kyon] {
+  def instance[A](implicit cls: ClassTag[A]): Kyon[A] = new Kyon(cls)
+  def newtype[Repr]: Newtype[Repr]                    = new Newtype[Repr]
+
+  class Newtype[Repr] {
+    def instance[A](implicit cls: ClassTag[Repr]): Kyon[A] = new Kyon(cls)
+  }
+}
+
+class KyonSuite extends AnyFlatSpec {
+  import KyonSuite._
+
+  "newtype derivation" should "implicitly receive classtag" in {
+    assert(implicitly[Kyon[Datus[Unit]]].cls === classTag[String])
+  }
+}
+
+object KyonSuite {
+  @derive(Kyon)
+  @newtype
+  case class Datus[@phantom A](x: String)
+}

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -26,4 +26,8 @@ object Version {
   val typedSchema = "0.14.2"
 
   val scalaCheck = "1.15.2"
+
+  val estatico = "0.4.4"
+
+  val munit = "0.7.21"
 }

--- a/pureconfig/src/main/scala/derevo/pureconfig/pureconfig.scala
+++ b/pureconfig/src/main/scala/derevo/pureconfig/pureconfig.scala
@@ -2,23 +2,24 @@ package derevo.pureconfig
 
 import derevo.{Derevo, Derivation, delegating}
 import pureconfig.{ConfigReader, ConfigWriter}
+import derevo.NewTypeDerivation
 
 @delegating("pureconfig.generic.semiauto.deriveReader")
-object pureconfigReader extends Derivation[ConfigReader] {
+object pureconfigReader extends Derivation[ConfigReader] with NewTypeDerivation[ConfigReader] {
   def instance[A]: ConfigReader[A] = macro Derevo.delegate[ConfigReader, A]
 }
 
 @delegating("pureconfig.generic.semiauto.deriveWriter")
-object pureconfigWriter extends Derivation[ConfigWriter] {
+object pureconfigWriter extends Derivation[ConfigWriter] with NewTypeDerivation[ConfigWriter] {
   def instance[A]: ConfigWriter[A] = macro Derevo.delegate[ConfigWriter, A]
 }
 
 @delegating("pureconfig.module.magnolia.semiauto.reader.deriveReader")
-object config extends Derivation[ConfigReader] {
+object config extends Derivation[ConfigReader] with NewTypeDerivation[ConfigReader] {
   def instance[A]: ConfigReader[A] = macro Derevo.delegate[ConfigReader, A]
 }
 
 @delegating("pureconfig.module.magnolia.semiauto.writer.deriveWriter")
-object configWriter extends Derivation[ConfigWriter] {
+object configWriter extends Derivation[ConfigWriter] with NewTypeDerivation[ConfigWriter] {
   def instance[A]: ConfigWriter[A] = macro Derevo.delegate[ConfigWriter, A]
 }

--- a/reactivemongo/src/main/scala/derevo/reactivemongo/package.scala
+++ b/reactivemongo/src/main/scala/derevo/reactivemongo/package.scala
@@ -8,12 +8,14 @@ package object reactivemongo {
   type BsonValueWriter[A] = BSONWriter[A, _ <: BSONValue]
 
   @delegating("reactivemongo.bson.Macros.writer")
-  object bsonDocumentWriter extends PolyDerivation[BsonValueWriter, BSONDocumentWriter] {
+  object bsonDocumentWriter
+      extends PolyDerivation[BsonValueWriter, BSONDocumentWriter] with NewTypeDerivation[BSONDocumentWriter] {
     def instance[A]: BSONDocumentWriter[A] = macro Derevo.delegate[BSONDocumentWriter, A]
   }
 
   @delegating("reactivemongo.bson.Macros.reader")
-  object bsonDocumentReader extends PolyDerivation[BsonValueReader, BSONDocumentReader] {
+  object bsonDocumentReader
+      extends PolyDerivation[BsonValueReader, BSONDocumentReader] with NewTypeDerivation[BSONDocumentReader] {
     def instance[A]: BSONDocumentReader[A] = macro Derevo.delegate[BSONDocumentReader, A]
   }
 }

--- a/scalacheck/src/main/scala/derevo/scalacheck/arbitrary.scala
+++ b/scalacheck/src/main/scala/derevo/scalacheck/arbitrary.scala
@@ -5,8 +5,9 @@ import magnolia.{CaseClass, Magnolia, Param, SealedTrait}
 import mercator.Monadic
 import org.scalacheck.{Arbitrary, Gen}
 import arbitraryInstances._
+import derevo.NewTypeDerivation
 
-object arbitrary extends Derivation[Arbitrary] {
+object arbitrary extends Derivation[Arbitrary] with NewTypeDerivation[Arbitrary] {
   type Typeclass[T] = Arbitrary[T]
 
   def combine[T](ctx: CaseClass[Arbitrary, T]): Arbitrary[T] =

--- a/tethys/src/main/scala/derevo/tethys/tethys.scala
+++ b/tethys/src/main/scala/derevo/tethys/tethys.scala
@@ -3,9 +3,10 @@ package derevo.tethys
 import derevo.{Derevo, Derivation, PolyDerivation, delegating}
 import tethys.derivation.builder._
 import tethys.{JsonObjectWriter, JsonReader, JsonWriter}
+import derevo.NewTypeDerivation
 
 @delegating("tethys.derivation.semiauto.jsonReader")
-object tethysReader extends Derivation[JsonReader] {
+object tethysReader extends Derivation[JsonReader] with NewTypeDerivation[JsonReader] {
   def instance[A]: JsonReader[A] = macro Derevo.delegate[JsonReader, A]
 
   def apply[A](arg: ReaderDerivationConfig): JsonReader[A] =
@@ -13,7 +14,7 @@ object tethysReader extends Derivation[JsonReader] {
 }
 
 @delegating("tethys.derivation.semiauto.jsonWriter")
-object tethysWriter extends PolyDerivation[JsonWriter, JsonObjectWriter] {
+object tethysWriter extends PolyDerivation[JsonWriter, JsonObjectWriter] with NewTypeDerivation[JsonWriter] {
   def instance[A]: JsonObjectWriter[A] = macro Derevo.delegate[JsonObjectWriter, A]
 
   def apply[A](arg: WriterDerivationConfig): JsonObjectWriter[A] =

--- a/tethysMagnolia/src/main/scala/derevo/tethys/tethysMagnolia.scala
+++ b/tethysMagnolia/src/main/scala/derevo/tethys/tethysMagnolia.scala
@@ -13,6 +13,7 @@ import tethys.{JsonReader, JsonWriter}
 
 import scala.collection.mutable
 import scala.language.experimental.macros
+import derevo.NewTypeDerivation
 
 case class CodecConfig(
     discriminator: Option[String] = None,
@@ -46,7 +47,7 @@ object CodecConfig {
   val upperSnakecase: String => String = snakecase andThen (_.toUpperCase)
 }
 
-object jsonWriter extends Derivation[JsonWriter] {
+object jsonWriter extends Derivation[JsonWriter] with NewTypeDerivation[JsonWriter]{
   type Typeclass[A] = JsonWriter[A]
 
   abstract class RecordJsonWriter[A] extends JsonWriter[A] {
@@ -92,7 +93,7 @@ object jsonWriter extends Derivation[JsonWriter] {
   def instance[A]: JsonWriter[A] = macro Magnolia.gen[A]
 }
 
-object jsonReader extends Derivation[JsonReader] {
+object jsonReader extends Derivation[JsonReader] with NewTypeDerivation[JsonReader] {
   type Typeclass[A] = JsonReader[A]
 
   abstract class RecordJsonReader[A] extends JsonReader[A] {


### PR DESCRIPTION
fixes #56
Note that derevo-core dependency does not brings the estatico dependency.
Moreover, the mechanism could be easily extended for the "marks" of the other "newtype" libraries