### PR TITLE
Fix parametric derivation

### DIFF
--- a/core/src/main/scala/derevo/package.scala
+++ b/core/src/main/scala/derevo/package.scala
@@ -8,14 +8,30 @@ package derevo {
   class delegating(to: String, args: Any*) extends StaticAnnotation
   class phantom                            extends StaticAnnotation
 
+  //* numeration according to https://docs.tofu.tf/docs/internal/kind-enumeration
   sealed trait InstanceDef
-  trait Derivation[TC[_]]                  extends InstanceDef
-  trait DerivationK1[TC[_[_]]]             extends InstanceDef
-  trait DerivationK2[TC[_[_[_]]]]          extends InstanceDef
-  trait PolyDerivation[FromTC[_], ToTC[_]] extends InstanceDef
+  trait Derivation[TC[_]]                        extends InstanceDef
+  trait DerivationKN1[TC[f[_]]]                  extends InstanceDef
+  trait DerivationKN2[TC[bf[_, _]]]              extends InstanceDef
+  trait DerivationKN3[TC[alg[f[_]]]]             extends InstanceDef
+  trait DerivationKN4[TC[tr[f[_], _]]]           extends InstanceDef
+  trait DerivationKN5[TC[tf[_, _, _]]]           extends InstanceDef
+  trait DerivationKN11[TC[alg[bf[_, _]]]]        extends InstanceDef
+  trait DerivationKN17[TC[alg[btr[_, _], _, _]]] extends InstanceDef
+  trait PolyDerivation[FromTC[_], ToTC[_]]       extends InstanceDef
+
 }
 
 package object derevo {
   type InjectInstancesHere >: Null
   def insertInstancesHere(): InjectInstancesHere = null
+
+  type DerivationK1[TC[f[_]]]               = DerivationKN1[TC]
+  type DerivationBi1[TC[f[_, _]]]           = DerivationKN2[TC]
+  type DerivationTri1[TC[f[_, _, _]]]       = DerivationKN5[TC]
+  type DerivationK2[TC[alg[f[_]]]]          = DerivationKN3[TC]
+  type DerivationHK[TC[alg[f[_]]]]          = DerivationKN3[TC]
+  type DerivationBi2[TC[alf[bf[_, _]]]]     = DerivationKN11[TC]
+  type DerivationTr[TC[T[f[_], a]]]         = DerivationKN4[TC]
+  type DerivationBiTr[TC[T[f[_, _], a, b]]] = DerivationKN17[TC]
 }

--- a/core/src/test/scala-2.13/derevo/KumamoSuite.scala
+++ b/core/src/test/scala-2.13/derevo/KumamoSuite.scala
@@ -1,0 +1,19 @@
+package derevo
+
+class Kumamo[U[f[_]]]
+
+object Kumamo extends DerivationHK[Kumamo] {
+  def instance[U[f[_]]]: Kumamo[U] = new Kumamo
+}
+
+class Anksu[G[f[_, _], _, _]]
+
+object Anksu extends DerivationBiTr[Anksu] {
+  def instance[U[f[_, _], _, _]]: Anksu[U] = new Anksu
+}
+
+@derive(Kumamo)
+class Xormeg[A, B[_], C[-_, +_[_]], F[_]]
+
+@derive(Anksu)
+class Jusprako[X, Y[-_ <: X] >: X, +F[_, _], -A, +B]


### PR DESCRIPTION
Makes derevo respect parameters to the left of the list
required  by the typeclass kind
Make all higher-kinded derivations do not cascade constraints by default
fixes #211 