### PR TITLE
Add NewType derivation for circe customizable encoder/decoder

### DIFF
--- a/circeMagnolia/src/main/scala/derevo/circe/magnolia/circe.scala
+++ b/circeMagnolia/src/main/scala/derevo/circe/magnolia/circe.scala
@@ -16,11 +16,11 @@ object encoder extends Derivation[Encoder] with NewTypeDerivation[Encoder] {
 }
 
 @delegating("io.circe.magnolia.configured.decoder.semiauto.deriveConfiguredMagnoliaDecoder")
-object customizableDecoder extends Derivation[Decoder] {
+object customizableDecoder extends Derivation[Decoder] with NewTypeDerivation[Decoder] {
   def instance[A]: Decoder[A] = macro Derevo.delegate[Decoder, A]
 }
 
 @delegating("io.circe.magnolia.configured.encoder.semiauto.deriveConfiguredMagnoliaEncoder")
-object customizableEncoder extends Derivation[Encoder] {
+object customizableEncoder extends Derivation[Encoder] with NewTypeDerivation[Encoder] {
   def instance[A]: Encoder[A] = macro Derevo.delegate[Encoder, A]
 }


### PR DESCRIPTION
Is there a reason this was not originally included? I've added the NewType derivations, and the current tests still run fine.