### PR TITLE
Add pureconfig-legacy module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,18 +69,19 @@ val common = List(
   licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 )
 
-lazy val core           = project settings common
-lazy val cats           = project dependsOn core settings common
-lazy val circe          = project dependsOn core settings common
-lazy val circeMagnolia  = project dependsOn core settings common
-lazy val ciris          = project dependsOn core settings common settings (scalacOptions -= "-Xfatal-warnings")
-lazy val tethys         = project dependsOn core settings common
-lazy val tethysMagnolia = project dependsOn core settings common
-lazy val reactivemongo  = project dependsOn core settings common
-lazy val catsTagless    = project dependsOn core settings common
-lazy val pureconfig     = project dependsOn core settings common
-lazy val scalacheck     = project dependsOn core settings common
-lazy val tests          =
+lazy val core                = project settings common
+lazy val cats                = project dependsOn core settings common
+lazy val circe               = project dependsOn core settings common
+lazy val circeMagnolia       = project dependsOn core settings common
+lazy val ciris               = project dependsOn core settings common settings (scalacOptions -= "-Xfatal-warnings")
+lazy val tethys              = project dependsOn core settings common
+lazy val tethysMagnolia      = project dependsOn core settings common
+lazy val reactivemongo       = project dependsOn core settings common
+lazy val catsTagless         = project dependsOn core settings common
+lazy val pureconfig          = project dependsOn core settings common
+lazy val `pureconfig-legacy` = project dependsOn core settings common
+lazy val scalacheck          = project dependsOn core settings common
+lazy val tests               =
   project
     .dependsOn(core, circe, ciris, tethys, reactivemongo, catsTagless, pureconfig)
     .settings(common, publish / skip := true)
@@ -98,6 +99,7 @@ lazy val derevo = project
     reactivemongo,
     catsTagless,
     pureconfig,
+    `pureconfig-legacy`,
     scalacheck,
     tests,
   )

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -11,6 +11,8 @@ object Version {
 
   val circeDerivation = "0.12.0-M7"
 
+  val pureConfigLegacy = "0.14.1"
+
   val pureConfig = "0.15.0"
 
   val magnolia = "0.17.0"

--- a/pureconfig-legacy/build.sbt
+++ b/pureconfig-legacy/build.sbt
@@ -1,0 +1,6 @@
+moduleName := "derevo-pureconfig-legacy"
+
+libraryDependencies += "com.github.pureconfig" %% "pureconfig"          % Version.pureConfigLegacy
+libraryDependencies += "com.github.pureconfig" %% "pureconfig-magnolia" % Version.pureConfigLegacy
+
+libraryDependencies += "org.scalatest" %% "scalatest" % Version.scalaTest % "test"

--- a/pureconfig-legacy/src/main/scala/derevo/pureconfig/pureconfig.scala
+++ b/pureconfig-legacy/src/main/scala/derevo/pureconfig/pureconfig.scala
@@ -1,0 +1,25 @@
+package derevo.pureconfig
+
+import derevo.{Derevo, Derivation, delegating}
+import pureconfig.{ConfigReader, ConfigWriter}
+import derevo.NewTypeDerivation
+
+@delegating("pureconfig.generic.semiauto.deriveReader")
+object pureconfigReader extends Derivation[ConfigReader] with NewTypeDerivation[ConfigReader] {
+  def instance[A]: ConfigReader[A] = macro Derevo.delegate[ConfigReader, A]
+}
+
+@delegating("pureconfig.generic.semiauto.deriveWriter")
+object pureconfigWriter extends Derivation[ConfigWriter] with NewTypeDerivation[ConfigWriter] {
+  def instance[A]: ConfigWriter[A] = macro Derevo.delegate[ConfigWriter, A]
+}
+
+@delegating("pureconfig.module.magnolia.semiauto.reader.deriveReader")
+object config extends Derivation[ConfigReader] with NewTypeDerivation[ConfigReader] {
+  def instance[A]: ConfigReader[A] = macro Derevo.delegate[ConfigReader, A]
+}
+
+@delegating("pureconfig.module.magnolia.semiauto.writer.deriveWriter")
+object configWriter extends Derivation[ConfigWriter] with NewTypeDerivation[ConfigWriter] {
+  def instance[A]: ConfigWriter[A] = macro Derevo.delegate[ConfigWriter, A]
+}

--- a/pureconfig-legacy/src/test/scala/derevo/pureconfig/DerivationSpec.scala
+++ b/pureconfig-legacy/src/test/scala/derevo/pureconfig/DerivationSpec.scala
@@ -1,0 +1,37 @@
+package derevo.pureconfig
+
+import derevo.derive
+import com.typesafe.config.ConfigFactory
+import pureconfig.{ConfigReader, ConfigSource, ConfigWriter}
+import pureconfig.syntax._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+@derive(pureconfigReader, pureconfigWriter)
+case class Credentials(login: String, password: String)
+
+@derive(pureconfigReader, pureconfigWriter)
+case class Foo[A](m: A)
+
+class DerivationSpec extends AnyFunSuite with Matchers {
+
+  def roundTrip[A: ConfigReader: ConfigWriter](value: A): Unit = {
+    val raw = value.toConfig.render
+    ConfigSource.fromConfig(ConfigFactory.parseString(raw)).load[A] shouldBe Right(value)
+  }
+
+  test("writes and reads simple config") {
+    roundTrip(Credentials("guest", "123"))
+  }
+
+  test("writes and reads config with parameter") {
+    roundTrip(
+      Foo(
+        Map(
+          "s1" -> Credentials("admin", "admin"),
+          "s2" -> Credentials("test", "test")
+        )
+      )
+    )
+  }
+}

--- a/pureconfig-legacy/src/test/scala/derevo/pureconfig/DerivationSpecMagnolia.scala
+++ b/pureconfig-legacy/src/test/scala/derevo/pureconfig/DerivationSpecMagnolia.scala
@@ -1,0 +1,37 @@
+package derevo.pureconfig
+
+import derevo.derive
+import com.typesafe.config.ConfigFactory
+import pureconfig.{ConfigReader, ConfigSource, ConfigWriter}
+import pureconfig.syntax._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+@derive(config, configWriter)
+case class CredentialsM(login: String, password: String)
+
+@derive(config, configWriter)
+case class FooM[A](m: A)
+
+class DerivationSpecMagnolia extends AnyFunSuite with Matchers {
+
+  def roundTrip[A: ConfigReader: ConfigWriter](value: A): Unit = {
+    val raw = value.toConfig.render
+    ConfigSource.fromConfig(ConfigFactory.parseString(raw)).load[A] shouldBe Right(value)
+  }
+
+  test("writes and reads simple config") {
+    roundTrip(CredentialsM("guest", "123"))
+  }
+
+  test("writes and reads config with parameter") {
+    roundTrip(
+      FooM(
+        Map(
+          "s1" -> CredentialsM("admin", "admin"),
+          "s2" -> CredentialsM("test", "test")
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
`derevo-pureconfig` depends on pureconfig 0.15.0
`derevo-pureconfig-legacy` depends on pureconfig 0.14.1

This will allow one to update `derevo` without forcing the whole project to migrate to CE3.