### PR TITLE
WIP: add support for local imports

### DIFF
--- a/modules/tests/src/main/scala/derevo/tests/LocalImport.scala
+++ b/modules/tests/src/main/scala/derevo/tests/LocalImport.scala
@@ -1,0 +1,12 @@
+package derevo.tests
+
+import derevo._
+
+object LocalImportTest {
+  import derevo.circe.codec
+
+  object a {}
+  import a._
+
+  @derive(codec) case class Foo()
+}


### PR DESCRIPTION
Closes #250

Compatibility with newtypes is not tested
This still won't work with pattern `object a { ... }; import a._` as this implementation does typechecking for each import statement that appears before `@derive` annotation
This implementation also uses deprecated enclosingTree API and may not work in future