### PR TITLE
Derivation object composition

### DIFF
--- a/modules/core/src/main/scala/derevo/package.scala
+++ b/modules/core/src/main/scala/derevo/package.scala
@@ -5,6 +5,8 @@ package derevo {
     def macroTransform(annottees: Any*): Any = macro Derevo.deriveMacro
   }
 
+  class composite(instances: Any*) extends StaticAnnotation
+
   /** */
   trait PassTypeArgs
   trait KeepRefinements
@@ -25,6 +27,8 @@ package derevo {
   trait DerivationKN11[TC[alg[bf[_, _]]]]             extends InstanceDef
   trait DerivationKN17[TC[alg[btr[_, _], _, _]]]      extends InstanceDef
   trait SpecificDerivation[FromTC[_], ToTC[_], NT[_]] extends InstanceDef
+
+  class CompositeDerivation extends InstanceDef
 
 }
 

--- a/modules/core/src/test/scala/derevo/CompositionSuite.scala
+++ b/modules/core/src/test/scala/derevo/CompositionSuite.scala
@@ -1,0 +1,23 @@
+package derevo
+
+trait Part1[T]
+trait Part2[T]
+
+object p1 extends Derivation[Part1] {
+  def instance[T]: Part1[T] = new Part1[T] {}
+}
+
+object p2 extends Derivation[Part2] {
+  def instance[T]: Part2[T] = new Part2[T] {}
+}
+
+@composite(p1, p2)
+object p1AndP2 extends CompositeDerivation
+
+@derive(p1AndP2)
+case class HasP1AndP2()
+
+object RefinementTest {
+  val part1: Part1[HasP1AndP2] = implicitly
+  val part2: Part2[HasP1AndP2] = implicitly
+}


### PR DESCRIPTION
This PR allows to define composed derivation objects using this syntax

```
trait Part1[T]
trait Part2[T]

object p1 extends Derivation[Part1] {
  def instance[T]: Part1[T] = new Part1[T] {}
}

object p2 extends Derivation[Part2] {
  def instance[T]: Part2[T] = new Part2[T] {}
}

@composite(p1, p2)
object p1AndP2 extends CompositeDerivation

@derive(p1AndP2)
case class HasP1AndP2()
```