### PR TITLE
Better newtype handling in reactivemongo

### DIFF
--- a/modules/reactivemongo/src/main/scala/derevo/reactivemongo/package.scala
+++ b/modules/reactivemongo/src/main/scala/derevo/reactivemongo/package.scala
@@ -20,4 +20,10 @@ package object reactivemongo {
       with NewTypeDerivation[BSONDocumentReader] {
     def instance[A]: BSONDocumentReader[A] = macro Derevo.delegate[BSONDocumentReader, A]
   }
+
+  @delegating("reactivemongo.bson.Macros.writer")
+  object bsonNewtypeWriter extends Derivation[BsonValueWriter] with NewTypeDerivation[BsonValueWriter]
+
+  @delegating("reactivemongo.bson.Macros.reader")
+  object bsonNewtypeReader extends Derivation[BsonValueReader] with NewTypeDerivation[BsonValueReader]
 }

--- a/modules/reactivemongo/src/test/scala/derevo/reactivemongo/DerivedHandlerSpec.scala
+++ b/modules/reactivemongo/src/test/scala/derevo/reactivemongo/DerivedHandlerSpec.scala
@@ -1,10 +1,11 @@
 package derevo.reactivemongo
 
 import derevo.derive
+import io.estatico.newtype.macros.newtype
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.refspec.RefSpec
-import reactivemongo.bson.{BSONDocumentReader, BSONDocumentWriter, BSONInteger, BSONString, document}
+import reactivemongo.bson.{BSONReader, BSONInteger, BSONDocumentWriter, document, BSONString, BSONDocumentReader}
 
 @derive(bsonDocumentWriter, bsonDocumentReader)
 case class Peka(yoba: String, amount: Int)
@@ -12,12 +13,33 @@ case class Peka(yoba: String, amount: Int)
 @derive(bsonDocumentWriter, bsonDocumentReader)
 case class Pekarnya[T](yoba: String, peka: T)
 
+object newtypeStuff {
+  @derive(bsonNewtypeWriter, bsonNewtypeReader)
+  @newtype
+  case class Newtypo(str: String)
+
+  @derive(bsonDocumentWriter, bsonDocumentReader)
+  case class NewtypoContainer(newtypo: Newtypo)
+}
+
+import newtypeStuff._
+
 class DerivedHandlerSpec extends RefSpec with Matchers {
   object `Derived writer` {
     def `should serialize`: Assertion = {
       implicitly[BSONDocumentWriter[Peka]].write(Peka("azaza", 42)) shouldBe document(
         "yoba"   -> BSONString("azaza"),
         "amount" -> BSONInteger(42)
+      )
+    }
+
+    def `should serialize newtype`: Assertion = {
+      implicitly[BsonValueWriter[Newtypo]].write(Newtypo("azaza")) shouldBe BSONString("azaza")
+    }
+
+    def `should serialize newtype container`: Assertion = {
+      implicitly[BSONDocumentWriter[NewtypoContainer]].write(NewtypoContainer(Newtypo("azaza"))) shouldBe document(
+        "newtypo" -> BSONString("azaza"),
       )
     }
 
@@ -40,6 +62,20 @@ class DerivedHandlerSpec extends RefSpec with Matchers {
           "amount" -> BSONInteger(42)
         )
       ) shouldBe Peka("azaza", 42)
+    }
+
+    def `should deserialize newtype`: Assertion = {
+      implicitly[BsonValueReader[Newtypo]]
+        .asInstanceOf[BSONReader[BSONString, Newtypo]] // hack to avoid covariance hell
+        .read(BSONString("azaza")) shouldBe Newtypo("azaza")
+    }
+
+    def `should deserialize newtype container`: Assertion = {
+      implicitly[BSONDocumentReader[NewtypoContainer]].read(
+        document(
+          "newtypo" -> BSONString("azaza"),
+        )
+      ) shouldBe NewtypoContainer(Newtypo("azaza"))
     }
 
     def `should deserialize polymorphic classes`: Assertion = {


### PR DESCRIPTION
This PR defines two new derivation objects - `bsonNewtypeWriter` and `bsonNewtypeReader` - which should be used with non-document newtypes

Minor issue: `BsonValueReader` is defined as `BSONReader[_ <: BSONValue, x]`, so it is not really possible to use this type as is (it will require coercing to something like `BSONReader[BSONString, x]`), but using readers directly on newtype objects is not so common case I think.

Fixes #312