### PR TITLE
Try to derive in unqualified mode when typechecking is not possible

### DIFF
--- a/modules/core/src/main/scala/derevo/Derevo.scala
+++ b/modules/core/src/main/scala/derevo/Derevo.scala
@@ -9,11 +9,11 @@ class Derevo(val c: blackbox.Context) {
   type Newtype      = NewtypeP[Tree]
   type NameAndTypes = NameAndTypesP[Tree, c.Type]
 
-  val CompositeSymbol       = typeOf[composite].typeSymbol
-  val DelegatingSymbol      = typeOf[delegating].typeSymbol
-  val PhantomSymbol         = typeOf[phantom].typeSymbol
-  val PassTypeArgsSymbol    = typeOf[PassTypeArgs].typeSymbol
-  val KeepRefinementsSymbol = typeOf[KeepRefinements].typeSymbol
+  val CompositeSymbol    = typeOf[composite].typeSymbol
+  val DelegatingSymbol   = typeOf[delegating].typeSymbol
+  val PhantomSymbol      = typeOf[phantom].typeSymbol
+  val PassTypeArgsSymbol = typeOf[PassTypeArgs].typeSymbol
+  val UnqualifiedSymbol  = typeOf[Unqualified].typeSymbol
 
   val instanceDefs         = Vector(
   )
@@ -224,25 +224,25 @@ class Derevo(val c: blackbox.Context) {
       def fixFirstTypeParam = {
         val nothingT = c.typeOf[Nothing]
 
-      c.typecheck(mode.call.duplicate, silent = true, withMacrosDisabled = true) match {
-        case q"$method[$nothing, ..$remainingTpes](..$args)" if nothing.tpe == nothingT =>
-          q"$method[$outTyp, ..$remainingTpes](..$args)"
-        case q"$method[$nothing, ..$remainingTpes]" if nothing.tpe == nothingT          =>
-          q"$method[$outTyp, ..$remainingTpes]"
-        case EmptyTree =>
-          mode.call match {
-            case q"$method(..$args)" =>
-              q"$method[$outTyp](..$args)"
-            case q"$method"         =>
-              q"$method[$outTyp]"
-            case _                                                                          => tree
-          }
-        case _                                                                          => tree
+        c.typecheck(mode.call.duplicate, silent = true, withMacrosDisabled = true) match {
+          case q"$method[$nothing, ..$remainingTpes](..$args)" if nothing.tpe == nothingT =>
+            q"$method[$outTyp, ..$remainingTpes](..$args)"
+          case q"$method[$nothing, ..$remainingTpes]" if nothing.tpe == nothingT          =>
+            q"$method[$outTyp, ..$remainingTpes]"
+          case EmptyTree                                                                  =>
+            mode.call match {
+              case q"$method(..$args)" =>
+                q"$method[$outTyp](..$args)"
+              case q"$method"          =>
+                q"$method[$outTyp]"
+              case _                   => tree
+            }
+          case _                                                                          => tree
+        }
       }
-    }
 
       if (allTparams.isEmpty || allTparams.length <= mode.drop) {
-        if (mode.keepRefinements) {
+        if (mode.unqualified) {
           q"""
           @java.lang.SuppressWarnings(scala.Array("org.wartremover.warts.All", "scalafix:All", "all"))
           implicit val $tn = $fixFirstTypeParam
@@ -272,7 +272,7 @@ class Derevo(val c: blackbox.Context) {
             }
           else Nil
 
-        if (mode.keepRefinements) {
+        if (mode.unqualified) {
           q"""
           @java.lang.SuppressWarnings(scala.Array("org.wartremover.warts.All", "scalafix:All", "all"))
           implicit def $tn[..$tparams](implicit ..$implicits) = $fixFirstTypeParam
@@ -320,12 +320,15 @@ class Derevo(val c: blackbox.Context) {
     val mangledName = obj.toString.replaceAll("[^\\w]", "_")
     val name        = c.freshName(mangledName)
 
-    val call   = extractCall(tree, newType)
+    val call        = extractCall(tree, newType)
     val tcheckedObj = c.typecheck(obj, silent = true)
     if (tcheckedObj.isEmpty) {
-      c.warning(c.enclosingPosition, s"Could not typecheck `$obj`, will try unqualified mode. If you are using local import for derivation object - replace it with package-level import")
+      c.warning(
+        c.enclosingPosition,
+        s"Could not typecheck `$obj`, will try unqualified mode. If you are using local import for derivation object - replace it with package-level import"
+      )
 
-      return new NameAndTypes(call, name, NoType, NoType, NoType, 0, false, true,false)
+      return List(new NameAndTypes(call, name, NoType, NoType, NoType, 0, false, true, false))
     }
 
     val objTyp = tcheckedObj.tpe
@@ -351,12 +354,12 @@ class Derevo(val c: blackbox.Context) {
       case _                => false
     }
 
-    val keepRefinements = objTyp.baseType(KeepRefinementsSymbol) match {
+    val unqualified = objTyp.baseType(UnqualifiedSymbol) match {
       case TypeRef(_, _, _) => true
       case _                => false
     }
 
-    nt.map(_.copy(passArgs = passArgs, keepRefinements = keepRefinements))
+    nt.map(_.copy(passArgs = passArgs, unqualified = unqualified))
   }
 
   trait DerivationMatcher {
@@ -410,7 +413,7 @@ object Derevo {
       newtype: typ,
       drop: Int,
       cascade: Boolean,
-      keepRefinements: Boolean = false,
+      unqualified: Boolean = false,
       passArgs: Boolean = false,
   )
 }

--- a/modules/core/src/main/scala/derevo/package.scala
+++ b/modules/core/src/main/scala/derevo/package.scala
@@ -9,7 +9,7 @@ package derevo {
 
   /** */
   trait PassTypeArgs
-  trait KeepRefinements
+  trait Unqualified
 
   class delegating(to: String, args: Any*) extends StaticAnnotation
   class phantom                            extends StaticAnnotation

--- a/modules/core/src/test/scala/derevo/DerivationSuite.scala
+++ b/modules/core/src/test/scala/derevo/DerivationSuite.scala
@@ -20,7 +20,13 @@ object DerivationSuite {
   @derive(Prefixed.dummy)
   sealed trait Baz
 
+  import Prefixed._
+
+  @derive(dummy)
+  sealed trait Bark
+
   def checkFoo[A: DummyTC] = implicitly[DummyTC[Foo[A]]]
   def checkBar             = implicitly[DummyTC[Bar.type]]
   def checkBaz             = implicitly[DummyTC[Baz]]
+  def checkBark            = implicitly[DummyTC[Bark]]
 }

--- a/modules/tests/src/main/scala/derevo/tests/Refinement.scala
+++ b/modules/tests/src/main/scala/derevo/tests/Refinement.scala
@@ -4,12 +4,12 @@ import derevo._
 
 trait Trait[T]
 
-object refinedTrait extends Derivation[Trait] with KeepRefinements {
+object refinedTrait extends Derivation[Trait] with Unqualified {
   def apply[T, A](a: A): Trait[T] { type Refinement = A }                = new Trait[T] { type Refinement = A }
   def singleTparam[T](dummy: Int): Trait[T] { type Refinement = String } = new Trait[T] { type Refinement = String }
 }
 
-object refinedTraitWithInstanceMethod extends Derivation[Trait] with KeepRefinements {
+object refinedTraitWithInstanceMethod extends Derivation[Trait] with Unqualified {
   def instance[T]: Trait[T] { type Refinement = String } = new Trait[T] { type Refinement = String }
 }
 


### PR DESCRIPTION
This PR allows to use derivation objects with local imports in most simple cases
The implementation is not as pure as we would like, therefore this mode will emit a warning

Fixes #250 